### PR TITLE
ci: fix Flatpak build rofiles-fuse and machine-id failures in container

### DIFF
--- a/.github/workflows/flatpak-release.yml
+++ b/.github/workflows/flatpak-release.yml
@@ -68,6 +68,16 @@ jobs:
           # Drop the .git so it isn't re-published as repo content.
           rm -rf "$GITHUB_WORKSPACE/packaging/linux/flatpak-repo/.git" 2>/dev/null || true
 
+      - name: Ensure dbus machine-id (container has none)
+        # The flatpak-builder image ships no /etc/machine-id, so dbus activation
+        # during the build can't start a bus. Generate one before building.
+        run: |
+          mkdir -p /var/lib/dbus
+          if [ ! -s /etc/machine-id ]; then
+            dbus-uuidgen | tee /etc/machine-id /var/lib/dbus/machine-id >/dev/null 2>&1 \
+              || dbus-uuidgen --ensure=/etc/machine-id
+          fi
+
       - name: Build, sign, and bundle
         working-directory: packaging/linux
         env:
@@ -75,6 +85,8 @@ jobs:
           GPG_HOMEDIR: ${{ env.GNUPGHOME }}
           RUNTIME_REPO_URL: ${{ env.FLATPAKREPO_URL }}
           STRICT: '0'
+          # rofiles-fuse (FUSE) can't spawn inside the CI container; opt out.
+          DISABLE_ROFILES_FUSE: '1'
         run: |
           ./build-flatpak.sh build
           ./build-flatpak.sh repo

--- a/packaging/linux/build-flatpak.sh
+++ b/packaging/linux/build-flatpak.sh
@@ -22,6 +22,15 @@ GPG_KEY_ID="${GPG_KEY_ID:-}"
 GPG_HOMEDIR="${GPG_HOMEDIR:-}"
 RUNTIME_REPO_URL="${RUNTIME_REPO_URL:-}"
 
+# DISABLE_ROFILES_FUSE  Set to 1 in containerized CI where rofiles-fuse can't
+#                       spawn (FUSE unavailable). Harmless to leave unset locally.
+DISABLE_ROFILES_FUSE="${DISABLE_ROFILES_FUSE:-0}"
+
+# Shared flatpak-builder flags. rofiles-fuse mounts the build cache read-only
+# mid-build via FUSE, which fails inside CI containers; let CI opt out.
+BUILDER_FLAGS=()
+[ "$DISABLE_ROFILES_FUSE" = "1" ] && BUILDER_FLAGS+=("--disable-rofiles-fuse")
+
 # Build the shared --gpg-sign/--gpg-homedir argument list into the named array.
 # Usage: gpg_sign_args MYARRAY ; then expand "${MYARRAY[@]}".
 gpg_sign_args() {
@@ -150,7 +159,7 @@ cmd_build() {
     echo "==> Building Flatpak..."
     echo "    (clones ProjectNotes + SqliteSyncPro from GitHub at pinned commits;"
     echo "     ensure those commits are pushed to origin first)"
-    flatpak-builder --force-clean "$BUILD_DIR" "$MANIFEST"
+    flatpak-builder "${BUILDER_FLAGS[@]}" --force-clean "$BUILD_DIR" "$MANIFEST"
     echo "==> Build complete. Output in $BUILD_DIR"
 }
 
@@ -165,7 +174,7 @@ cmd_run() {
 
 cmd_install() {
     echo "==> Installing Flatpak for current user..."
-    flatpak-builder --user --install --force-clean "$BUILD_DIR" "$MANIFEST"
+    flatpak-builder "${BUILDER_FLAGS[@]}" --user --install --force-clean "$BUILD_DIR" "$MANIFEST"
     echo "==> Installed. Run with: flatpak run $APP_ID"
 }
 
@@ -183,7 +192,7 @@ cmd_repo() {
     else
         echo "==> Exporting to repository at $REPO_DIR (unsigned; set GPG_KEY_ID to sign)..."
     fi
-    flatpak-builder --repo="$REPO_DIR" "${sign_args[@]}" --force-clean "$BUILD_DIR" "$MANIFEST"
+    flatpak-builder "${BUILDER_FLAGS[@]}" --repo="$REPO_DIR" "${sign_args[@]}" --force-clean "$BUILD_DIR" "$MANIFEST"
     echo "==> Repository created at $REPO_DIR"
 }
 


### PR DESCRIPTION
## Problem

The `Flatpak Release` workflow fails during `./build-flatpak.sh build` inside the `ghcr.io/flathub-infra/flatpak-github-actions:kde-6.9` container with:

```
Can't find bus: Cannot spawn a message bus without a machine-id: Unable to load
  /var/lib/dbus/machine-id or /etc/machine-id ...
Error: Failure spawning rofiles-fuse, exit_status: 256
```

Both are container-environment issues, not problems with the manifest or sources:

1. **rofiles-fuse (fatal).** `flatpak-builder` mounts its build cache read-only mid-build via `rofiles-fuse`. FUSE doesn't work reliably inside the CI container even with `--privileged`, so the spawn fails and aborts the build.
2. **machine-id.** The container ships no `/etc/machine-id`, so dbus activation during the build can't start a bus.

## Fix

- **`packaging/linux/build-flatpak.sh`** — add an env-gated `DISABLE_ROFILES_FUSE` knob (off by default) that appends `--disable-rofiles-fuse` to all `flatpak-builder` calls (`build`, `install`, `repo`). Local Fedora builds are unchanged and keep the build-cache safety check.
- **`.github/workflows/flatpak-release.yml`** — generate a machine-id before building, and set `DISABLE_ROFILES_FUSE=1` for the build step.

## Verification

- Push a `v*` tag (or use `workflow_dispatch`) and confirm the build gets past "Starting build of com.projectnotespro.ProjectNotes" and completes `build`/`repo`/`bundle` without either error.
- Local: `./build-flatpak.sh build` with `DISABLE_ROFILES_FUSE` unset behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)