### PR TITLE
ci: complete Flatpak release pipeline fixes (tar, repo seed, GPG signing)

### DIFF
--- a/.github/workflows/flatpak-release.yml
+++ b/.github/workflows/flatpak-release.yml
@@ -57,16 +57,23 @@ jobs:
 
       - name: Fetch already-published repo (preserve update history)
         # Clone the live ostree repo so flatpak-builder exports incrementally
-        # into it; existing users get a delta, not a full re-download. Empty on
-        # the very first release — that's fine, we start a fresh repo.
+        # into it; existing users get a delta, not a full re-download. Only seed
+        # flatpak-repo when the clone is a real ostree repo (has objects/) —
+        # otherwise flatpak-builder aborts with "opendir(objects)". On the first
+        # release gh-pages holds only the staged extras (.flatpakrepo/icon), so
+        # we start fresh and let flatpak-builder initialize the repo.
         run: |
-          git clone --branch "$PAGES_BRANCH" --depth 1 \
-            "https://x-access-token:${{ secrets.FLATPAK_PAGES_DEPLOY_TOKEN }}@github.com/${PAGES_REPO}.git" \
-            "$RUNNER_TEMP/published" 2>/dev/null && \
-            cp -a "$RUNNER_TEMP/published" "$GITHUB_WORKSPACE/packaging/linux/flatpak-repo" || \
-            echo "No existing repo yet — starting fresh."
-          # Drop the .git so it isn't re-published as repo content.
-          rm -rf "$GITHUB_WORKSPACE/packaging/linux/flatpak-repo/.git" 2>/dev/null || true
+          DEST="$GITHUB_WORKSPACE/packaging/linux/flatpak-repo"
+          if git clone --branch "$PAGES_BRANCH" --depth 1 \
+               "https://x-access-token:${{ secrets.FLATPAK_PAGES_DEPLOY_TOKEN }}@github.com/${PAGES_REPO}.git" \
+               "$RUNNER_TEMP/published" 2>/dev/null && [ -d "$RUNNER_TEMP/published/objects" ]; then
+            cp -a "$RUNNER_TEMP/published" "$DEST"
+            # Drop the .git so it isn't re-published as repo content.
+            rm -rf "$DEST/.git" 2>/dev/null || true
+            echo "Seeded from published ostree repo (preserving update history)."
+          else
+            echo "No published ostree repo yet — starting fresh."
+          fi
 
       - name: Ensure dbus machine-id (container has none)
         # The flatpak-builder image ships no /etc/machine-id, so dbus activation

--- a/.github/workflows/flatpak-release.yml
+++ b/.github/workflows/flatpak-release.yml
@@ -12,6 +12,8 @@ name: Flatpak Release
 # Required repository secrets (Settings > Secrets and variables > Actions):
 #   FLATPAK_GPG_PRIVATE_KEY   ASCII-armored private signing key (full block)
 #   FLATPAK_GPG_KEY_ID        The signing key's ID / fingerprint / uid
+#   FLATPAK_GPG_PASSPHRASE    Passphrase for the signing key (preset into the
+#                             agent so ostree can sign non-interactively)
 #   FLATPAK_PAGES_DEPLOY_TOKEN  PAT with `repo` scope on projectnotes-flatpak
 #
 # First-run checklist lives in docs/Introduction/InstallLinux.md.
@@ -49,10 +51,29 @@ jobs:
           flatpak install -y --noninteractive flathub io.qt.qtwebengine.BaseApp//6.9
 
       - name: Import GPG signing key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.FLATPAK_GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.FLATPAK_GPG_PASSPHRASE }}
         run: |
           export GNUPGHOME="$RUNNER_TEMP/gnupg"
           mkdir -p "$GNUPGHOME"; chmod 700 "$GNUPGHOME"
-          printf '%s' "${{ secrets.FLATPAK_GPG_PRIVATE_KEY }}" | gpg --batch --import
+          # The signing key is passphrase-protected and ostree signs via gpgme/
+          # gpg-agent with no pinentry in this container. Let the agent take a
+          # preset passphrase and cache it long enough to outlast the ~25-min
+          # build before the export signs the commit.
+          printf '%s\n' allow-loopback-pinentry allow-preset-passphrase \
+            'default-cache-ttl 21600' 'max-cache-ttl 21600' \
+            > "$GNUPGHOME/gpg-agent.conf"
+          gpgconf --kill gpg-agent || true
+          printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
+          # Preset the passphrase for every (sub)key keygrip so signing the
+          # ostree commit needs no interactive prompt.
+          preset="$(gpgconf --list-dirs libexecdir)/gpg-preset-passphrase"
+          gpg --batch --with-colons --with-keygrip --list-secret-keys \
+            | awk -F: '$1 == "grp" { print $10 }' \
+            | while read -r grip; do
+                printf '%s' "$GPG_PASSPHRASE" | "$preset" --preset "$grip"
+              done
           echo "GNUPGHOME=$GNUPGHOME" >> "$GITHUB_ENV"
 
       - name: Fetch already-published repo (preserve update history)

--- a/packaging/linux/python-pyqt6-webengine.yaml
+++ b/packaging/linux/python-pyqt6-webengine.yaml
@@ -36,7 +36,9 @@ build-commands:
     # QtWebEngineWidgets; QWebEnginePage/printToPdf in QtWebEngineCore). Skip
     # QtWebEngineQuick (QML). --jobs capped low to bound memory use.
     # NB: unlike PyQt6, PyQt6-WebEngine's sip-wheel has no --confirm-license flag.
-    tar xf pyqt6_webengine-6.9.0.tar.gz
+    # --no-same-owner: as root in the CI user namespace, restoring the
+    # archive's original uid/gid (501:20) fails with EINVAL and aborts tar.
+    tar xf pyqt6_webengine-6.9.0.tar.gz --no-same-owner
     cd pyqt6_webengine-6.9.0
     # sip resolves imported PyQt6 .sip files under <target_dir>/PyQt6/bindings,
     # and target_dir defaults to the build interpreter's site-packages (in /usr,

--- a/packaging/linux/python-pyqt6.yaml
+++ b/packaging/linux/python-pyqt6.yaml
@@ -37,7 +37,9 @@ build-commands:
     #    Building all ~35 modules is unnecessary and exhausts RAM on small hosts.
     #    --jobs is capped low for the same reason (each g++ on the generated
     #    sources is memory-hungry); raise it if the build host has plenty of RAM.
-    tar xf pyqt6-6.9.1.tar.gz
+    # --no-same-owner: as root in the CI user namespace, restoring the
+    # archive's original uid/gid (501:20) fails with EINVAL and aborts tar.
+    tar xf pyqt6-6.9.1.tar.gz --no-same-owner
     cd pyqt6-6.9.1
     sip-wheel --confirm-license --verbose \
         --qmake /usr/bin/qmake6 \


### PR DESCRIPTION
Follow-up to #102, which was merged early and only included the first fix
(rofiles-fuse + machine-id). This adds the remaining three fixes needed to get
the `Flatpak Release` workflow running fully green end-to-end.

After each fix, the workflow advanced one stage further; the final run completes
build → sign → bundle → stage → **deploy to the Pages ostree repo** successfully.

## Commits

- **`--no-same-owner` on PyQt6 extraction** — as root in the CI user namespace,
  `tar` restoring the archive's original uid/gid (501:20) fails with EINVAL and
  aborts the `python3-pyqt6` module (exit 2).
- **Seed `flatpak-repo` only from a real ostree repo** — the export aborted with
  `opening repo: opendir(objects): No such file or directory` because on the
  first release the `gh-pages` branch holds only staged extras, not an ostree
  repo. Seed only when `objects/` is present; otherwise start fresh.
- **Preset the GPG passphrase into the agent** — ostree signing failed with
  `GPG Agent: No pinentry`. The passphrase-protected key is now unlocked by
  presetting the passphrase (allow-preset-passphrase + loopback, long cache TTL)
  so signing the commit ~25 min into the build needs no prompt. Requires the new
  `FLATPAK_GPG_PASSPHRASE` repo secret (already added).

## Verification

Triggered via `workflow_dispatch` on this branch — run completes successfully
through the deploy step; the signed ostree repo is published to
`kestermckinney/projectnotes-flatpak`. (The "Attach bundle to the Release" step
is tag-gated and intentionally skipped on manual dispatch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)